### PR TITLE
Refactor kiln dropoff viewer: improve logging and add date_created filtering

### DIFF
--- a/functions/ceramics/kiln_dropoff_recent_entries_viewer/lambda_function.py
+++ b/functions/ceramics/kiln_dropoff_recent_entries_viewer/lambda_function.py
@@ -204,26 +204,20 @@ def lambda_handler(event, context):
         # 3. Get API token from Secrets Manager
         api_token = get_secret(SECRET_NAME, 'CLICKUP_API_TOKEN')
         
-        # --- MORE DEBUGGING CODE ---
-        if api_token:
-            print(f"--- DEBUG: API Token loaded successfully.")
-            # NEW: More detailed logging to verify the token string is clean
-            print(f"--- DEBUG: Token Length: {len(api_token)}")
-            print(f"--- DEBUG: Token Starts With: '{api_token[:8]}...'")
-            print(f"--- DEBUG: Token Ends With: '...{api_token[-4:]}'")
-        else:
-            print("--- DEBUG ERROR: API Token IS MISSING OR NULL after calling get_clickup_api_token().")
-        # --- END OF MORE DEBUGGING CODE ---
-        
+        if not api_token:
+            print("ERROR: API Token is missing or null.")
+
         # 4. Fetch recent tasks from ClickUp API
         twenty_four_hours_ago = datetime.now(timezone.utc) - timedelta(hours=24)
         timestamp_ms = int(twenty_four_hours_ago.timestamp() * 1000)
+        print(f"--- INFO: Fetching tasks created after {twenty_four_hours_ago.isoformat()} (timestamp: {timestamp_ms})")
 
-        tasks = get_all_clickup_tasks(list_id, api_token, date_created_gt=timestamp_ms)
-        
-        # MODIFIED: Sort the tasks manually since the API parameter was removed
+        tasks = get_all_clickup_tasks(list_id, api_token, date_created_gt_ms=timestamp_ms)
+        print(f"--- INFO: Retrieved {len(tasks)} tasks from ClickUp")
+
+        # Sort by date_created descending (newest first)
         tasks.sort(key=lambda x: int(x.get('date_created', 0)), reverse=True)
-        
+
         # 5. Generate and return the HTML page
         html_body = generate_html_page(tasks)
         

--- a/layers/common/python/common/clickup.py
+++ b/layers/common/python/common/clickup.py
@@ -141,7 +141,7 @@ def get_custom_field_value(task, field_id):
 
     return None
 
-def fetch_clickup_tasks_page(list_id, api_token, page_num, due_date_lt_ms=None, due_date_gt_ms=None, include_subtasks=False, include_closed=False):
+def fetch_clickup_tasks_page(list_id, api_token, page_num, due_date_lt_ms=None, due_date_gt_ms=None, date_created_gt_ms=None, date_created_lt_ms=None, include_subtasks=False, include_closed=False):
     """
     Fetches a single page of tasks from the ClickUp API with optional date ranges.
     """
@@ -157,13 +157,17 @@ def fetch_clickup_tasks_page(list_id, api_token, page_num, due_date_lt_ms=None, 
         query_params["due_date_lt"] = due_date_lt_ms
     if due_date_gt_ms is not None:
         query_params["due_date_gt"] = due_date_gt_ms
+    if date_created_gt_ms is not None:
+        query_params["date_created_gt"] = date_created_gt_ms
+    if date_created_lt_ms is not None:
+        query_params["date_created_lt"] = date_created_lt_ms
 
     data = _make_clickup_request(api_token, "GET", endpoint, params=query_params)
     tasks_on_page = data.get('tasks', [])
     is_last_page = data.get('last_page', True) if not tasks_on_page else data.get('last_page', False)
     return tasks_on_page, is_last_page
 
-def get_all_clickup_tasks(list_id, api_token, due_date_lt_ms=None, due_date_gt_ms=None, max_pages=20, **kwargs):
+def get_all_clickup_tasks(list_id, api_token, due_date_lt_ms=None, due_date_gt_ms=None, date_created_gt_ms=None, date_created_lt_ms=None, max_pages=20):
     """
     Fetches all tasks from a ClickUp list, paginating as necessary.
     """
@@ -180,6 +184,7 @@ def get_all_clickup_tasks(list_id, api_token, due_date_lt_ms=None, due_date_gt_m
         tasks_on_page, is_last_page = fetch_clickup_tasks_page(
             list_id, api_token, current_page,
             due_date_lt_ms=due_date_lt_ms, due_date_gt_ms=due_date_gt_ms,
+            date_created_gt_ms=date_created_gt_ms, date_created_lt_ms=date_created_lt_ms,
             include_subtasks=include_subtasks, include_closed=include_closed
         )
 

--- a/templates/ceramics.yaml
+++ b/templates/ceramics.yaml
@@ -72,8 +72,18 @@ Resources:
         - Key: Project
           Value: ceramics:kiln-dropoff-viewer
 
+  KilnDropoffViewerLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/KilnDropoffRecentEntriesViewerFunction-${Stage}"
+      RetentionInDays: 30
+      Tags:
+        - Key: Project
+          Value: ceramics:kiln-dropoff-viewer
+
   KilnDropoffRecentEntriesViewerFunction:
     Type: AWS::Serverless::Function
+    DependsOn: KilnDropoffViewerLogGroup
     Properties:
       FunctionName: !Sub "KilnDropoffRecentEntriesViewerFunction-${Stage}"
       Description: "Generates a public-facing HTML page showing recent kiln drop-off submissions from ClickUp for the last 24 hours. Triggered by API Gateway."


### PR DESCRIPTION
## Summary
This PR improves the kiln dropoff viewer Lambda function by removing verbose debug logging, adding proper date_created filtering support to the ClickUp API layer, and establishing explicit CloudWatch log group management.

## Key Changes

- **Simplified debug logging**: Replaced verbose token inspection debug statements with concise error handling and informative task retrieval logging
- **Added date_created filtering**: Extended `fetch_clickup_tasks_page()` and `get_all_clickup_tasks()` functions to support `date_created_gt_ms` and `date_created_lt_ms` parameters for filtering tasks by creation date
- **Fixed API parameter naming**: Corrected the parameter name from `date_created_gt` to `date_created_gt_ms` in the Lambda handler to match the updated function signature
- **Improved task sorting**: Added explicit comment clarifying that tasks are sorted by creation date in descending order (newest first)
- **CloudWatch log group management**: Added explicit `KilnDropoffViewerLogGroup` resource with 30-day retention policy and proper dependency configuration in SAM template
- **Enhanced observability**: Added informative log statements for task fetch timestamp and retrieved task count

## Implementation Details

The date_created filtering parameters are now properly passed through the entire call chain:
- Lambda handler → `get_all_clickup_tasks()` → `fetch_clickup_tasks_page()` → ClickUp API query parameters

The CloudWatch log group is now explicitly managed as an infrastructure resource rather than relying on implicit Lambda log group creation, providing better control over retention policies and resource lifecycle.

https://claude.ai/code/session_01R8VWU6JpadXs7zfUcRajGk