### PR TITLE
Add staging deployment pipeline with SAM and AWS CloudFormation

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,60 @@
+name: Deploy Staging Pipeline
+
+on:
+  push:
+    branches:
+      - staging # This pipeline triggers on pushes to the 'staging' branch
+
+env:
+  AWS_REGION: us-east-2
+  SAM_STACK_NAME: AsmblyFacilitiesMaintTrackingStack-stage
+
+jobs:
+  # =================================================================
+  # JOB 1: Deploy the SAM application to AWS (staging)
+  # =================================================================
+  deploy:
+    outputs:
+      FACILITIES_API_URL: ${{ steps.get-api-url.outputs.API_URL }}
+    name: Deploy to AWS (staging)
+    environment: stage
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::110104886034:role/GitHub-OIDC-facilities-automation-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+
+      - name: Build SAM Application
+        run: sam build --use-container
+
+      - name: Deploy SAM Application
+        run: |
+          # Use the 'stage' environment config from samconfig.toml
+          # --no-confirm-changeset is required for automation
+          sam deploy --config-env stage --no-confirm-changeset
+
+      - name: Get API Gateway URL Output
+        id: get-api-url
+        run: |
+          echo "Fetching API Gateway URL from CloudFormation stack outputs..."
+          API_URL=$(aws cloudformation describe-stacks \
+            --stack-name ${{ env.SAM_STACK_NAME }} \
+            --query "Stacks[0].Outputs[?OutputKey=='FacilitiesApiUrl'].OutputValue" \
+            --output text)
+          if [ -z "$API_URL" ]; then
+            echo "::error::Failed to retrieve 'FacilitiesApiUrl' from stack outputs."
+            exit 1
+          fi
+          echo "API_URL=$API_URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
This PR introduces a new GitHub Actions workflow for automated deployment of the Facilities Maintenance Tracking application to the AWS staging environment.

## Key Changes
- **New workflow file**: `.github/workflows/deploy-staging.yml`
  - Triggers automatically on pushes to the `staging` branch
  - Configured for the `us-east-2` AWS region
  - Uses OIDC authentication with GitHub to assume an IAM role for secure, keyless AWS access

## Implementation Details
The workflow includes the following steps:

1. **Code checkout** - Retrieves the latest code from the repository
2. **AWS authentication** - Assumes the `GitHub-OIDC-facilities-automation-deploy` IAM role using OIDC
3. **SAM setup** - Installs the AWS SAM CLI for infrastructure deployment
4. **Build** - Builds the SAM application using Docker containers
5. **Deploy** - Deploys the application to CloudFormation using the `stage` environment configuration from `samconfig.toml`
6. **Output extraction** - Retrieves the API Gateway URL from CloudFormation stack outputs and exports it as a workflow output for downstream use

The workflow uses appropriate permissions (OIDC token write access) and runs on the latest Ubuntu environment. Error handling is included to fail the workflow if the API Gateway URL cannot be retrieved from the CloudFormation stack.

https://claude.ai/code/session_01CDifMgFdmgyt97yrSNpJnu