### PR TITLE
Add explicit CloudWatch log groups for Lambda functions

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -84,7 +84,7 @@ Resources:
         - ResourcePath: "/*"
           HttpMethod: "*"
           LoggingLevel: INFO
-          DataTraceEnabled: true
+          DataTraceEnabled: false
       DefinitionBody:
         openapi: '3.0.1'
         info:
@@ -166,7 +166,7 @@ Resources:
       ContentUri: layers/requests_layer/
       CompatibleRuntimes:
         - python3.12
-      RetentionPolicy: Retain
+      RetentionPolicy: Delete
 
   CommonLayer:
     Type: AWS::Serverless::LayerVersion
@@ -176,7 +176,7 @@ Resources:
       ContentUri: layers/common/
       CompatibleRuntimes:
         - python3.12
-      RetentionPolicy: Retain
+      RetentionPolicy: Delete
 
   ReactionMapPurchaseRequestParameter:
     Type: AWS::SSM::Parameter

--- a/templates/administrative.yaml
+++ b/templates/administrative.yaml
@@ -14,8 +14,18 @@ Parameters:
     Type: String
 
 Resources:
+  NewWaiverCompletedLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/NewWaiverCompletedFunction-${Stage}"
+      RetentionInDays: 14
+      Tags:
+        - Key: Project
+          Value: administrative:new-waiver-completed
+
   NewWaiverCompletedFunction:
     Type: AWS::Serverless::Function
+    DependsOn: NewWaiverCompletedLogGroup
     Properties:
       FunctionName: !Sub "NewWaiverCompletedFunction-${Stage}"
       Description: "Receives new waiver completion webhooks and updates NeonCRM."

--- a/templates/facilities.yaml
+++ b/templates/facilities.yaml
@@ -80,8 +80,18 @@ Resources:
         - Key: Project
           Value: facilities:pm-reminder-bot
 
+  PMReminderBotLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/PMReminderBotFunction-${Stage}"
+      RetentionInDays: 14
+      Tags:
+        - Key: Project
+          Value: facilities:pm-reminder-bot
+
   PMReminderBotFunction:
     Type: AWS::Serverless::Function
+    DependsOn: PMReminderBotLogGroup
     Properties:
       FunctionName: !Sub "PMReminderBotFunction-${Stage}"
       Description: "Scheduled function that fetches overdue and upcoming preventative maintenance tasks from ClickUp and sends reminder notifications to the appropriate Slack channels."

--- a/templates/problem_report.yaml
+++ b/templates/problem_report.yaml
@@ -71,8 +71,18 @@ Resources:
         - Key: Project
           Value: problem-report:new-request-received
 
+  NewProblemReportRequestReceivedLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/NewProblemReportRequestReceived-${Stage}"
+      RetentionInDays: 14
+      Tags:
+        - Key: Project
+          Value: problem-report:new-request-received
+
   NewProblemReportRequestReceivedFunction:
     Type: AWS::Serverless::Function
+    DependsOn: NewProblemReportRequestReceivedLogGroup
     Properties:
       FunctionName: !Sub "NewProblemReportRequestReceived-${Stage}"
       Description: "Handles a new problem report request from a Google Form."
@@ -136,8 +146,18 @@ Resources:
         - Key: Project
           Value: problem-report:slack-reaction
 
+  ProblemReportReactionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/ProblemReport-ReactionFunction-${Stage}"
+      RetentionInDays: 14
+      Tags:
+        - Key: Project
+          Value: problem-report:slack-reaction
+
   ProblemReportReactionFunction:
     Type: AWS::Serverless::Function
+    DependsOn: ProblemReportReactionLogGroup
     Properties:
       FunctionName: !Sub "ProblemReport-ReactionFunction-${Stage}"
       Description: "Handles a Slack reaction on a problem report to update ClickUp and Discourse."

--- a/templates/purchase_request.yaml
+++ b/templates/purchase_request.yaml
@@ -66,8 +66,18 @@ Resources:
         - Key: Project
           Value: purchase-request:slack-reorder
 
+  SlackSlashReorderLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/SlackSlashReorderFunction-${Stage}"
+      RetentionInDays: 14
+      Tags:
+        - Key: Project
+          Value: purchase-request:slack-reorder
+
   SlackSlashReorderFunction:
     Type: AWS::Serverless::Function
+    DependsOn: SlackSlashReorderLogGroup
     Properties:
       FunctionName: !Sub "SlackSlashReorderFunction-${Stage}"
       Description: "Handles a Slack slash command to create a reorder/purchase request in ClickUp."
@@ -158,8 +168,18 @@ Resources:
         - Key: Project
           Value: purchase-request:slack-reaction
 
+  PurchaseRequestReactionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/PurchaseRequest-ReactionFunction-${Stage}"
+      RetentionInDays: 14
+      Tags:
+        - Key: Project
+          Value: purchase-request:slack-reaction
+
   PurchaseRequestReactionFunction:
     Type: AWS::Serverless::Function
+    DependsOn: PurchaseRequestReactionLogGroup
     Properties:
       FunctionName: !Sub "PurchaseRequest-ReactionFunction-${Stage}"
       Description: "Handles a Slack reaction webhook to update a ClickUp task status."
@@ -216,8 +236,18 @@ Resources:
         - Key: Project
           Value: purchase-request:clickup-webhook
 
+  NewPurchaseRequestReceivedLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/NewPurchaseRequestReceivedFunction-${Stage}"
+      RetentionInDays: 14
+      Tags:
+        - Key: Project
+          Value: purchase-request:clickup-webhook
+
   NewPurchaseRequestReceivedFunction:
     Type: AWS::Serverless::Function
+    DependsOn: NewPurchaseRequestReceivedLogGroup
     Properties:
       FunctionName: !Sub "NewPurchaseRequestReceivedFunction-${Stage}"
       Description: "Handles a ClickUp webhook for new purchase requests, posts to Slack, and updates the task."

--- a/templates/routers.yaml
+++ b/templates/routers.yaml
@@ -13,8 +13,18 @@ Parameters:
   RouterConfigParameterName: { Type: String }
 
 Resources:
+  SlackEventRouterLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/facilities-slack-event-router-${Stage}"
+      RetentionInDays: 14
+      Tags:
+        - Key: Project
+          Value: router:slack-event
+
   SlackEventSubscriptionsRouterFunction:
     Type: AWS::Serverless::Function
+    DependsOn: SlackEventRouterLogGroup
     Properties:
       FunctionName: !Sub "facilities-slack-event-router-${Stage}"
       Description: "Routes incoming Slack events to the correct handler function."


### PR DESCRIPTION
## Summary
This PR adds explicit AWS CloudWatch LogGroup resources for all Lambda functions across the infrastructure templates, with a 14-day retention policy. Additionally, it updates API Gateway data trace logging and layer retention policies for better cost optimization.

## Key Changes
- **CloudWatch Log Groups**: Created explicit `AWS::Logs::LogGroup` resources for 7 Lambda functions:
  - `SlackSlashReorderLogGroup` (purchase_request.yaml)
  - `PurchaseRequestReactionLogGroup` (purchase_request.yaml)
  - `NewPurchaseRequestReceivedLogGroup` (purchase_request.yaml)
  - `NewProblemReportRequestReceivedLogGroup` (problem_report.yaml)
  - `ProblemReportReactionLogGroup` (problem_report.yaml)
  - `NewWaiverCompletedLogGroup` (administrative.yaml)
  - `PMReminderBotLogGroup` (facilities.yaml)
  - `SlackEventRouterLogGroup` (routers.yaml)

- **Lambda Dependencies**: Added `DependsOn: [LogGroupName]` to each corresponding Lambda function to ensure log groups are created before the functions

- **API Gateway Logging**: Disabled data trace logging (`DataTraceEnabled: false`) in the API Gateway stage to reduce log verbosity and costs

- **Layer Retention**: Changed layer retention policy from `Retain` to `Delete` for both `RequestsLayer` and `CommonLayer` to allow automatic cleanup of old layer versions

## Implementation Details
- All log groups are configured with a 14-day retention period
- Log group names follow the pattern `/aws/lambda/[FunctionName]-${Stage}`
- Each log group is tagged with a `Project` tag for resource organization
- The explicit log group creation prevents AWS from auto-creating them with default settings and ensures consistent retention policies across all functions

https://claude.ai/code/session_01MqxX5ctaBj2yPT3hNSzHjf