### PR TITLE
Add a lint step to testing, with aws tooling

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,6 +10,29 @@ on:
       - stage
 
 jobs:
+  lint-templates:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.12'
+
+      - name: Install cfn-lint
+        run: pip install cfn-lint
+
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+
+      - name: Lint root application template
+        run: sam validate --lint --template-file template.yaml
+
+      - name: Lint CI/CD (deployer role) template
+        run: sam validate --lint --template-file template-cicd.yaml
+
   test:
     runs-on: ubuntu-latest
 

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -5,6 +5,7 @@
 - [Prerequisites](#prerequisites)
 - [Architecture Overview](#architecture-overview)
 - [CI/CD Infrastructure (The Deployer Role)](#cicd-infrastructure-the-deployer-role)
+- [Linting & Validating Templates](#linting--validating-templates)
 - [Automated Production Deployment (via GitHub Actions)](#automated-production-deployment-via-github-actions)
 - [Manual Deployment (for Dev & Stage)](#manual-deployment-for-dev--stage)
 
@@ -43,6 +44,20 @@ For example, if you add an SQS queue to `template.yaml` and the `prod` deploy fa
     sam deploy --template-file template-cicd.yaml --stack-name AsmblyFacilitiesMaintTrackingStack-cicd --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM --region us-east-2
     ```
 3.  **Re-run** the failed GitHub Actions job.
+
+> **Note:** Some `AWS::Serverless::Function` properties imply extra IAM actions the deployer role needs, beyond the obvious `lambda:CreateFunction`/`UpdateFunctionConfiguration`. For example, setting `ReservedConcurrentExecutions` requires `lambda:PutFunctionConcurrency` (and `lambda:DeleteFunctionConcurrency` if it's ever removed). Watch the `CREATE_FAILED`/`UPDATE_FAILED` reason in the CloudFormation console or `aws cloudformation describe-stack-events` output — it names the exact missing action.
+
+## Linting & Validating Templates
+
+Before pushing changes, validate all SAM templates locally to catch schema errors, obsolete `DependsOn`, and other issues without waiting on a full deploy:
+
+```bash
+pip install -r requirements-dev.txt  # installs cfn-lint
+sam validate --lint --template-file template.yaml
+sam validate --lint --template-file template-cicd.yaml
+```
+
+`sam validate --lint` runs `cfn-lint` after the SAM transform is applied, so `Fn::GetAtt` references into nested stack (`/templates/*.yaml`) outputs resolve correctly (running raw `cfn-lint` against `template.yaml` directly produces false-positive `E1010`/`E1019` errors for these cross-stack references). This check also runs automatically in the `Python Tests` GitHub Actions workflow on every push and PR.
 
 ## Automated Production Deployment (via GitHub Actions)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ moto
 pytest-cov
 pytest-env
 tzdata
+cfn-lint

--- a/template.yaml
+++ b/template.yaml
@@ -480,8 +480,6 @@ Resources:
         Application: facilities-automation-hub
         Project: api:custom-domain
         Workspace: facilities
-    DependsOn:
-      - FacilitiesCertificate
 
   FacilitiesApiMapping:
     Type: AWS::ApiGatewayV2::ApiMapping
@@ -490,8 +488,6 @@ Resources:
       DomainName: !Ref FacilitiesApiCustomDomain
       ApiId: !Ref FacilitiesApi
       Stage: !Ref Stage # This will be 'prod' when IsProd is true
-    DependsOn:
-      - FacilitiesApiCustomDomain
 
   FacilitiesDnsRecord:
     Type: AWS::Route53::RecordSet
@@ -503,8 +499,6 @@ Resources:
       AliasTarget:
         HostedZoneId: !GetAtt FacilitiesApiCustomDomain.RegionalHostedZoneId
         DNSName: !GetAtt FacilitiesApiCustomDomain.RegionalDomainName
-    DependsOn:
-      - FacilitiesApiCustomDomain
 
 Outputs:
   FacilitiesApiUrl:

--- a/template.yaml
+++ b/template.yaml
@@ -503,7 +503,7 @@ Resources:
 Outputs:
   FacilitiesApiUrl:
     Description: "The invoke URL for the Facilities API Gateway"
-    Value: !Sub "https://{FacilitiesApi}.execute-api.${AWS::Region}.amazonaws.com/${Stage}"
+    Value: !Sub "https://${FacilitiesApi}.execute-api.${AWS::Region}.amazonaws.com/${Stage}"
 
   FacilitiesProdUrl:
     Description: "The custom, friendly URL for the PROD API Gateway"


### PR DESCRIPTION
Uses `aws sam --lint` invocation with a cnf-lint package installed.

Also fixes the found lint errors - just redundant references.